### PR TITLE
Forgot to read https://github.com/Ocramius/ProxyManager/tree/f65ae0f9dcbdd9d6ad3abb721a9e09c3d7d868a4#ocramiusproxy-manager-for-enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ By using this package, you'll gain a versioning policy that won't force you to
 use the latest version of PHP *and* Composer to get bugfixes and new features.
 
 This fork:
+
 - maintains compatibility with PHP `>=7.1`;
   supporting new versions of PHP is considered as a bugfix;
 - won't bump the minimum supported version of PHP in a minor release;


### PR DESCRIPTION
Upstream [already provides enterprise support and fixes for critical bugs in previous releases](https://github.com/Ocramius/ProxyManager/tree/f65ae0f9dcbdd9d6ad3abb721a9e09c3d7d868a4#ocramiusproxy-manager-for-enterprise), but package author explicitly decided to ignore it, and instead opens a cans of worms in support issues that will just hit the upstream project.

Free to do that: it's an MIT package, after all, but it still seems like instead of helping authors in maintaining their work, more issues are being raised because of having a fork that increases dependency graph complexity long-term (reads: "dick move", like in https://github.com/symfony/symfony/pull/39065).